### PR TITLE
Fix zero interval

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@ function PostgresInterval (raw) {
 }
 var properties = ['seconds', 'minutes', 'hours', 'days', 'months', 'years']
 PostgresInterval.prototype.toPostgres = function () {
-  return properties
-    .filter(this.hasOwnProperty, this)
+  var filtered = properties.filter(this.hasOwnProperty, this)
+  if (filtered.length === 0) return '0'
+  return filtered
     .map(function (property) {
       return this[property] + ' ' + property
     }, this)

--- a/test.js
+++ b/test.js
@@ -13,5 +13,6 @@ test(function (t) {
   t.equal(interval('01:02:03').toPostgres(), '3 seconds 2 minutes 1 hours')
   t.equal(interval('1 year -32 days').toPostgres(), '-32 days 1 years')
   t.equal(interval('1 day -00:00:03').toPostgres(), '-3 seconds 1 days')
+  t.equal(interval('00:00:00').toPostgres(), '0')
   t.end()
 })


### PR DESCRIPTION
Zero intervals are converted to `''` causing query to fail.

``` sql
select ''::interval
```

Results in `ERROR:  invalid input syntax for type interval: ""`.

This PR fixes the issue by converting zero interval to `'0'`.

``` sql
select '0'::interval
```
