### PR TITLE
Fixes parsing of microseconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ PostgresInterval.prototype.toPostgres = function () {
       // Account for fractional part of seconds,
       // remove trailing zeroes.
       if (property === 'seconds' && this.milliseconds)
-        value += '.' + String(this.milliseconds).replace(/0+$/g, '');
+        value += '.' + String(this.milliseconds * 1000).replace(/[0]+$/g, '');
 
       return value + ' ' + property;
     }, this)
@@ -37,7 +37,7 @@ var NUMBER = '([+-]?\\d+)'
 var YEAR = NUMBER + '\\s+years?'
 var MONTH = NUMBER + '\\s+mons?'
 var DAY = NUMBER + '\\s+days?'
-var TIME = '([+-])?([\\d]*):(\\d\\d):(\\d\\d)\.?(\\d{1,3})?'
+var TIME = '([+-])?([\\d]*):(\\d\\d):(\\d\\d)\.?(\\d{1,6})?'
 var INTERVAL = new RegExp([YEAR, MONTH, DAY, TIME].map(function (regexString) {
   return '(' + regexString + ')?'
 })
@@ -56,10 +56,11 @@ var positions = {
 // We can use negative time
 var negatives = ['hours', 'minutes', 'seconds']
 
-function parseSecondsFraction (fraction) {
+function parseMilliseconds (fraction) {
   // add omitted zeroes
-  var millis = fraction + '000'.slice(fraction.length);
-  return parseInt(millis, 10);
+  var microseconds = fraction + '000000'.slice(fraction.length);
+  console.log({fraction, microseconds})
+  return parseInt(microseconds, 10) / 1000;
 }
 
 function parse (interval) {
@@ -75,7 +76,7 @@ function parse (interval) {
       // milliseconds are actually microseconds (up to 6 digits)
       // with omitted trailing zeroes.
       value = property === 'milliseconds'
-        ? parseSecondsFraction(value)
+        ? parseMilliseconds(value)
         : parseInt(value, 10)
       // no zeros
       if (!value) return parsed

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var NUMBER = '([+-]?\\d+)'
 var YEAR = NUMBER + '\\s+years?'
 var MONTH = NUMBER + '\\s+mons?'
 var DAY = NUMBER + '\\s+days?'
-var TIME = '([+-])?([\\d]*):(\\d\\d):(\\d\\d):?(\\d\\d\\d)?'
+var TIME = '([+-])?([\\d]*):(\\d\\d):(\\d\\d)\.?(\\d{1,3})?'
 var INTERVAL = new RegExp([YEAR, MONTH, DAY, TIME].map(function (regexString) {
   return '(' + regexString + ')?'
 })
@@ -44,6 +44,12 @@ var positions = {
 // We can use negative time
 var negatives = ['hours', 'minutes', 'seconds']
 
+function parseSecondsFraction (fraction) {
+  // add omitted zeroes
+  var millis = fraction + '000'.slice(fraction.length);
+  return parseInt(millis, 10);
+}
+
 function parse (interval) {
   if (!interval) return {}
   var matches = INTERVAL.exec(interval)
@@ -54,7 +60,11 @@ function parse (interval) {
       var value = matches[position]
       // no empty string
       if (!value) return parsed
-      value = parseInt(value, 10)
+      // milliseconds are actually microseconds (up to 6 digits)
+      // with omitted trailing zeroes.
+      value = property === 'milliseconds'
+        ? parseSecondsFraction(value)
+        : parseInt(value, 10)
       // no zeros
       if (!value) return parsed
       if (isNegative && ~negatives.indexOf(property)) {

--- a/index.js
+++ b/index.js
@@ -15,20 +15,22 @@ PostgresInterval.prototype.toPostgres = function () {
   var filtered = properties.filter(this.hasOwnProperty, this)
 
   // In addition to `properties`, we need to account for fractions of seconds.
-  if (this.milliseconds && (-1 === filtered.indexOf('seconds')))
-    filtered.push('seconds');
+  if (this.milliseconds && (filtered.indexOf('seconds') === -1)) {
+    filtered.push('seconds')
+  }
 
   if (filtered.length === 0) return '0'
   return filtered
     .map(function (property) {
-      var value = this[property] || 0;
+      var value = this[property] || 0
 
       // Account for fractional part of seconds,
       // remove trailing zeroes.
-      if (property === 'seconds' && this.milliseconds)
-        value += '.' + String(this.milliseconds * 1000).replace(/[0]+$/g, '');
+      if (property === 'seconds' && this.milliseconds) {
+        value += '.' + String(this.milliseconds * 1000).replace(/[0]+$/g, '')
+      }
 
-      return value + ' ' + property;
+      return value + ' ' + property
     }, this)
     .join(' ')
 }
@@ -58,9 +60,9 @@ var negatives = ['hours', 'minutes', 'seconds']
 
 function parseMilliseconds (fraction) {
   // add omitted zeroes
-  var microseconds = fraction + '000000'.slice(fraction.length);
+  var microseconds = fraction + '000000'.slice(fraction.length)
   console.log({fraction, microseconds})
-  return parseInt(microseconds, 10) / 1000;
+  return parseInt(microseconds, 10) / 1000
 }
 
 function parse (interval) {

--- a/index.js
+++ b/index.js
@@ -13,10 +13,22 @@ function PostgresInterval (raw) {
 var properties = ['seconds', 'minutes', 'hours', 'days', 'months', 'years']
 PostgresInterval.prototype.toPostgres = function () {
   var filtered = properties.filter(this.hasOwnProperty, this)
+
+  // In addition to `properties`, we need to account for fractions of seconds.
+  if (this.milliseconds && (-1 === filtered.indexOf('seconds')))
+    filtered.push('seconds');
+
   if (filtered.length === 0) return '0'
   return filtered
     .map(function (property) {
-      return this[property] + ' ' + property
+      var value = this[property] || 0;
+
+      // Account for fractional part of seconds,
+      // remove trailing zeroes.
+      if (property === 'seconds' && this.milliseconds)
+        value += '.' + String(this.milliseconds).replace(/0+$/g, '');
+
+      return value + ' ' + property;
     }, this)
     .join(' ')
 }

--- a/index.js
+++ b/index.js
@@ -61,7 +61,6 @@ var negatives = ['hours', 'minutes', 'seconds']
 function parseMilliseconds (fraction) {
   // add omitted zeroes
   var microseconds = fraction + '000000'.slice(fraction.length)
-  console.log({fraction, microseconds})
   return parseInt(microseconds, 10) / 1000
 }
 

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ var test = require('tape')
 var interval = require('./')
 
 test(function (t) {
-  t.deepEqual(interval('01:02:03:456'), {
+  t.deepEqual(interval('01:02:03.456'), {
     hours: 1,
     minutes: 2,
     seconds: 3,
@@ -15,5 +15,9 @@ test(function (t) {
   t.equal(interval('1 year -32 days').toPostgres(), '-32 days 1 years')
   t.equal(interval('1 day -00:00:03').toPostgres(), '-3 seconds 1 days')
   t.equal(interval('00:00:00').toPostgres(), '0')
+  t.equal(interval('00:00:00.5').milliseconds, 500)
+  t.equal(interval('00:00:00.50').milliseconds, 500)
+  t.equal(interval('00:00:00.500').milliseconds, 500)
+  t.equal(interval('00:00:00.5000').milliseconds, 500)
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -21,5 +21,8 @@ test(function (t) {
   t.equal(interval('00:00:00.5000').milliseconds, 500)
   t.equal(interval('00:00:01.100').toPostgres(), '1.1 seconds')
   t.equal(interval('00:00:00.5').toPostgres(), '0.5 seconds')
+  t.equal(interval('00:00:00.100500').milliseconds, 100.5)
+  t.equal(interval('00:00:00.100500').toPostgres(), '0.1005 seconds')
+  t.equal(interval('00:00:00.123456').toPostgres(), '0.123456 seconds')
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -19,5 +19,7 @@ test(function (t) {
   t.equal(interval('00:00:00.50').milliseconds, 500)
   t.equal(interval('00:00:00.500').milliseconds, 500)
   t.equal(interval('00:00:00.5000').milliseconds, 500)
+  t.equal(interval('00:00:01.100').toPostgres(), '1.1 seconds')
+  t.equal(interval('00:00:00.5').toPostgres(), '0.5 seconds')
   t.end()
 })


### PR DESCRIPTION
See #7.

I didn't actually add `microseconds` property, but made `milliseconds` "float" instead.

This isn't a particularly beautiful code, but didn't feel right to refactor what's already there.
