### PR TITLE
My v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,34 @@
 language: node_js
-node_js:
-- iojs
+sudo: false
+env:
+  - PGUSER=postgres PGDATABASE=postgres
+
+matrix:
+  include:
+    # Older ones are from brianc/node-postgres, so let's roll with that.
+    - node_js: "0.10"
+      addons:
+        postgresql: "9.4"
+    - node_js: "0.12"
+      addons:
+        postgresql: "9.4"
+    - node_js: "4"
+      addons:
+        postgresql: "9.4"
+    - node_js: "5"
+      addons:
+        postgresql: "9.4"
+
+    # Test multiple Postgres versions for latest node.
+    - node_js: "6"
+      addons:
+        postgresql: "9.1"
+    - node_js: "6"
+      addons:
+        postgresql: "9.2"
+    - node_js: "6"
+      addons:
+        postgresql: "9.3"
+    - node_js: "6"
+      addons:
+        postgresql: "9.4"

--- a/index.js
+++ b/index.js
@@ -45,9 +45,9 @@ var defaults = units.reduce(function (self, label) {
  * @param  {String} string Database output.
  * @return {Object}
  */
+var captureUnitsRegexp = /([+-]?\d+ (?:years?|days?|mons?))/g
 var captureUnits = function (string) {
-  var re = /([+-]?\d+ (?:years?|days?|mons?))/g
-  var matches = string.match(re)
+  var matches = string.match(captureUnitsRegexp)
   var units = {}
 
   if (matches) {
@@ -69,9 +69,9 @@ var captureUnits = function (string) {
  * @param  {String} string Database output.
  * @return {Object}
  */
+var captureTimeRegexp = /((?:[+-]?\d+):(?:\d{2}):(?:\d{2})(?:\.\d{1,6})?)/
 var captureTime = function (string) {
-  var re = /((?:[+-]?\d+):(?:\d{2}):(?:\d{2})(?:\.\d{1,6})?)/
-  var matches = re.exec(string)
+  var matches = captureTimeRegexp.exec(string)
   var time = {}
 
   if (matches) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-'use strict';
+'use strict'
 
-const labels = {
+var labels = {
   'year': 'years',
   'years': 'years',
   'mon': 'months',
@@ -13,74 +13,72 @@ const labels = {
   'mins ': 'minutes',
   'sec': 'seconds',
   'secs': 'seconds'
-};
+}
 
-const units = Object.keys(labels)
+var units = Object.keys(labels)
   .map(key => labels[key])
-  .filter((val, idx, self) => self.indexOf(val) === idx);
+  .filter((val, idx, self) => self.indexOf(val) === idx)
 
-const defaults = units.reduce((self, label) => {
-  self[label] = 0;
-  return self;
-}, {});
+var defaults = units.reduce((self, label) => {
+  self[label] = 0
+  return self
+}, {})
 
 // Returns an array of labeled units and their amounts.
-const captureUnits = (string) => {
-  const re = /([+-]?\d+ (?:years?|days?|mons?))/g;
-  const matches = string.match(re);
-  const units = {};
+var captureUnits = (string) => {
+  var re = /([+-]?\d+ (?:years?|days?|mons?))/g
+  var matches = string.match(re)
+  var units = {}
 
   if (matches) {
     matches.forEach(unit => {
-      const [value, label] = unit.split(' ');
-      units[labels[label]] = parseFloat(value);
-    });
+      var [value, label] = unit.split(' ')
+      units[labels[label]] = parseFloat(value)
+    })
   }
 
-  return units;
-};
+  return units
+}
 
-const captureTime = (string) => {
-  const re = /((?:[+-]?\d+):(?:\d{2}):(?:\d{2})(?:\.\d{1,6})?)/;
-  const matches = re.exec(string);
-  let time = {};
+var captureTime = (string) => {
+  var re = /((?:[+-]?\d+):(?:\d{2}):(?:\d{2})(?:\.\d{1,6})?)/
+  var matches = re.exec(string)
+  var time = {}
 
   if (matches) {
-    let [hours, minutes, seconds] = matches[1].split(':').map(parseFloat);
+    var [hours, minutes, seconds] = matches[1].split(':').map(parseFloat)
 
     if (hours < 0) {
-      minutes = -minutes;
-      seconds = -seconds;
+      minutes = -minutes
+      seconds = -seconds
     }
 
-    time = {hours, minutes, seconds};
+    time = {hours, minutes, seconds}
   }
 
-  return time;
-};
+  return time
+}
 
-class PostgresInterval {
-  constructor (raw) {
-    Object.assign(
-      this,
-      {_raw: raw},
-      defaults,
-      captureUnits(raw),
-      captureTime(raw)
-    );
-  }
+function PostgresInterval (raw) {
+  Object.assign(
+    this,
+    {_raw: raw},
+    defaults,
+    captureUnits(raw),
+    captureTime(raw)
+  )
+}
 
-  toString () {
-    return units
-      .map(unit => `${this[unit]} ${unit}`)
-      .join(' ');
-  }
+PostgresInterval.prototype.toString = function () {
+  return this.toPostgres()
+}
 
-  toPostgres () {
-    return String(this);
-  }
+PostgresInterval.prototype.toPostgres = function () {
+  return units
+    .map(function (unit) { return this[unit] + ' ' + unit }, this)
+    .join(' ')
 }
 
 module.exports = function parseInterval (raw) {
-  return new PostgresInterval(raw);
-};
+  return new PostgresInterval(raw)
+}

--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@
 
 var xtend = require('xtend/mutable')
 
+/**
+ * Key is what Postgres uses,
+ * value is what we place into PostgresInterval instance.
+ * @type {Object}
+ */
 var labels = {
   'year': 'years',
   'years': 'years',
@@ -17,16 +22,29 @@ var labels = {
   'secs': 'seconds'
 }
 
+/**
+ * Awkward version of saying `Object.values(labels).unique()`.
+ * @type {[String]}
+ */
 var units = Object.keys(labels)
   .map(function (key) { return labels[key] })
   .filter(function (val, idx, self) { return self.indexOf(val) === idx })
 
+/**
+ * Generates defaults props for PostgresInterval instance.
+ * @type {Object} Keys are from `units`, values are 0.
+ */
 var defaults = units.reduce(function (self, label) {
   self[label] = 0
   return self
 }, {})
 
-// Returns an array of labeled units and their amounts.
+/**
+ * Returns object for extending PostgresInterval with,
+ * parses portion of the @string that contains `amount unit`.
+ * @param  {String} string Database output.
+ * @return {Object}
+ */
 var captureUnits = function (string) {
   var re = /([+-]?\d+ (?:years?|days?|mons?))/g
   var matches = string.match(re)
@@ -45,6 +63,12 @@ var captureUnits = function (string) {
   return units
 }
 
+/**
+ * Returns object for extending PostgresInterval with,
+ * parses time portion of the @string.
+ * @param  {String} string Database output.
+ * @return {Object}
+ */
 var captureTime = function (string) {
   var re = /((?:[+-]?\d+):(?:\d{2}):(?:\d{2})(?:\.\d{1,6})?)/
   var matches = re.exec(string)
@@ -88,6 +112,11 @@ PostgresInterval.prototype.toString = function () {
   return this.toPostgres()
 }
 
+/**
+ * Returns an interval string.
+ * This allows the interval object to be passed into prepared statements.
+ * @return {String}
+ */
 PostgresInterval.prototype.toPostgres = function () {
   return units
     .map(function (unit) { return this[unit] + ' ' + unit }, this)

--- a/index.js
+++ b/index.js
@@ -16,23 +16,26 @@ var labels = {
 }
 
 var units = Object.keys(labels)
-  .map(key => labels[key])
-  .filter((val, idx, self) => self.indexOf(val) === idx)
+  .map(function (key) { return labels[key] })
+  .filter(function (val, idx, self) { return self.indexOf(val) === idx })
 
-var defaults = units.reduce((self, label) => {
+var defaults = units.reduce(function (self, label) {
   self[label] = 0
   return self
 }, {})
 
 // Returns an array of labeled units and their amounts.
-var captureUnits = (string) => {
+var captureUnits = function (string) {
   var re = /([+-]?\d+ (?:years?|days?|mons?))/g
   var matches = string.match(re)
   var units = {}
 
   if (matches) {
-    matches.forEach(unit => {
-      var [value, label] = unit.split(' ')
+    matches.forEach(function (unit) {
+      var parts = unit.split(' ')
+      var value = parts[0]
+      var label = parts[1]
+
       units[labels[label]] = parseFloat(value)
     })
   }
@@ -40,14 +43,17 @@ var captureUnits = (string) => {
   return units
 }
 
-var captureTime = (string) => {
+var captureTime = function (string) {
   var re = /((?:[+-]?\d+):(?:\d{2}):(?:\d{2})(?:\.\d{1,6})?)/
   var matches = re.exec(string)
   var time = {}
 
   if (matches) {
     var isNegative = matches[0][0] === '-'
-    var [hours, minutes, seconds] = matches[1].split(':').map(parseFloat)
+    var parts = matches[1].split(':').map(parseFloat)
+    var hours = parts[0]
+    var minutes = parts[1]
+    var seconds = parts[2]
 
     if (isNegative) {
       // Invert non-zero amounts,
@@ -57,7 +63,11 @@ var captureTime = (string) => {
       seconds = 0 - seconds
     }
 
-    time = {hours, minutes, seconds}
+    time = {
+      hours: hours,
+      minutes: minutes,
+      seconds: seconds
+    }
   }
 
   return time

--- a/index.js
+++ b/index.js
@@ -46,11 +46,15 @@ var captureTime = (string) => {
   var time = {}
 
   if (matches) {
+    var isNegative = matches[0][0] === '-'
     var [hours, minutes, seconds] = matches[1].split(':').map(parseFloat)
 
-    if (hours < 0) {
-      minutes = -minutes
-      seconds = -seconds
+    if (isNegative) {
+      // Invert non-zero amounts,
+      // but do not convert 0 to -0.
+      hours = hours > 0 ? -hours : hours
+      minutes = 0 - minutes
+      seconds = 0 - seconds
     }
 
     time = {hours, minutes, seconds}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var xtend = require('xtend/mutable')
+
 var labels = {
   'year': 'years',
   'years': 'years',
@@ -74,9 +76,8 @@ var captureTime = function (string) {
 }
 
 function PostgresInterval (raw) {
-  Object.assign(
+  xtend(
     this,
-    {_raw: raw},
     defaults,
     captureUnits(raw),
     captureTime(raw)

--- a/package.json
+++ b/package.json
@@ -11,22 +11,21 @@
     "url": "bendrucker.me"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
-    "test": "standard && tape test.js"
+    "test": "mocha test.js"
   },
   "keywords": [
     "postgres",
     "interval",
     "parser"
   ],
-  "dependencies": {
-    "xtend": "^4.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
-    "tape": "^4.0.0",
-    "standard": "^4.0.0"
+    "expect.js": "^0.3.1",
+    "mocha": "^2.5.3",
+    "pg": "^6.0.2"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "pre-test": "standard",
-    "test": "tape test.js",
+    "pretest": "standard",
+    "test": "node test.js",
     "testw": "nodemon -w index.js -w test.js -x npm test"
   },
   "keywords": [
@@ -27,6 +27,7 @@
   "devDependencies": {
     "async": "^2.0.0",
     "pg": "^6.0.2",
+    "promise-polyfill": "^6.0.0",
     "standard": "^7.1.2",
     "tape": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "url": "bendrucker.me"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha test.js"
+    "pre-test": "standard",
+    "test": "tape test.js",
+    "testw": "nodemon -w index.js -w test.js -x npm test"
   },
   "keywords": [
     "postgres",
@@ -23,9 +25,10 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "expect.js": "^0.3.1",
-    "mocha": "^2.5.3",
-    "pg": "^6.0.2"
+    "async": "^2.0.0",
+    "pg": "^6.0.2",
+    "standard": "^7.1.2",
+    "tape": "^4.6.0"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "interval",
     "parser"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "xtend": "^4.0.1"
+  },
   "devDependencies": {
     "async": "^2.0.0",
     "pg": "^6.0.2",

--- a/test.js
+++ b/test.js
@@ -1,46 +1,82 @@
-'use strict';
+'use strict'
 
-const pg = require('pg');
-const expect = require('expect.js');
-const parse = require('.');
+var pg = require('pg')
+var tape = require('tape')
+var async = require('async')
+var parse = require('.')
 
-describe('PostgresInterval', () => {
-  const pool = new pg.Pool();
+// callback(err, [{
+//  input // String   element of `inputs` array
+//  pg    // String   how postgres parses it
+//  js    // String   how postgres-interval parses it
+//  ok    // Boolean  whether pg::interval = js::interval
+//                    (from database perspective)
+// }])
+function selectFromPostgres (callback) {
+  var pool = new pg.Pool()
+  var query = '' +
+    'select ' +
+    '  $1::text as input,' +
+    '  $1::interval::text as pg,' +
+    '  $2::text as js,' +
+    '  $1::interval = $2::interval as ok' +
+    ';'
 
-  const check = (input, cb) => {
-    const query = `
-      select
-        $1::interval::text as pg,
-        $2::text as js,
-        $1::interval = $2::interval as ok
-      ;
-    `;
+  var iterator = function (input, cb) {
+    var params = [input, parse(input)]
+    pool.query(query, params, function (err, results) {
+      cb(err, results ? results.rows[0] : undefined)
+    })
+  }
 
-    const params = [input || 0, parse(input)];
+  var done = function (err, results) {
+    pool.end()
+    callback(err, results)
+  }
 
-    it(input, (done) => {
-      pool.query(query, params, (err, result) => {
-        expect(err).to.be(null);
-        expect(result.rows[0].ok).to.be(true);
+  async.map([
+    '04:05:06.123456',
+    '1 year',
+    '2 days',
+    '3 mons',
+    '5 years 100 days',
+    '1 year 1 mon',
+    '2 mons 1 day',
+    '3 days 04:05:06.5',
+    '-1 year -2 mons +3 days -04:05:06',
+    '1 years 1 mon',
+    '3 days -1 year -2 mons -04:05:06',
+    '01:02:03',
+    '100:02:03',
+    '1 year -32 days',
+    '1 day -00:00:03',
+    '00:00:00',
+    '00:00:00.5',
+    '00:00:00.50',
+    '00:00:00.500',
+    '00:00:00.5000',
+    '00:00:01.100',
+    '00:00:00.5',
+    '00:00:00.100500',
+    '00:00:00.100500',
+    '00:00:00.123456'
+  ], iterator, done)
+}
 
-        if (process.env.hasOwnProperty('DEBUG'))
-          console.log(result.rows);
+function test (err, rows) {
+  if (err) {
+    throw new Error('selectFromPostgres() failed')
+  }
 
-        done();
-      });
-    });
-  };
+  tape('parseInterval()', function (t) {
+    rows.forEach(function (row) {
+      t.equal(row.ok, true, row.input)
+    })
 
-  ` 04:05:06.123456
-    1 year
-    2 days
-    3 mons
-    5 years 100 days
-    1 year 1 mon
-    2 mons 1 day
-    3 days 04:05:06.5
-    -1 year -2 mons +3 days -04:05:06
-    1 years 1 mon
-    3 days -1 year -2 mons -04:05:06
-  `.split('\n').slice(0, -1).map(s => s.trim()).forEach(check);
-});
+    t.end()
+  })
+}
+
+if (!module.parent) {
+  selectFromPostgres(test)
+}

--- a/test.js
+++ b/test.js
@@ -1,19 +1,46 @@
-'use strict'
+'use strict';
 
-var test = require('tape')
-var interval = require('./')
+const pg = require('pg');
+const expect = require('expect.js');
+const parse = require('.');
 
-test(function (t) {
-  t.deepEqual(interval('01:02:03:456'), {
-    hours: 1,
-    minutes: 2,
-    seconds: 3,
-    milliseconds: 456
-  })
-  t.equal(interval('01:02:03').toPostgres(), '3 seconds 2 minutes 1 hours')
-  t.equal(interval('100:02:03').toPostgres(), '3 seconds 2 minutes 100 hours')
-  t.equal(interval('1 year -32 days').toPostgres(), '-32 days 1 years')
-  t.equal(interval('1 day -00:00:03').toPostgres(), '-3 seconds 1 days')
-  t.equal(interval('00:00:00').toPostgres(), '0')
-  t.end()
-})
+describe('PostgresInterval', () => {
+  const pool = new pg.Pool();
+
+  const check = (input, cb) => {
+    const query = `
+      select
+        $1::interval::text as pg,
+        $2::text as js,
+        $1::interval = $2::interval as ok
+      ;
+    `;
+
+    const params = [input || 0, parse(input)];
+
+    it(input, (done) => {
+      pool.query(query, params, (err, result) => {
+        expect(err).to.be(null);
+        expect(result.rows[0].ok).to.be(true);
+
+        if (process.env.hasOwnProperty('DEBUG'))
+          console.log(result.rows);
+
+        done();
+      });
+    });
+  };
+
+  ` 04:05:06.123456
+    1 year
+    2 days
+    3 mons
+    5 years 100 days
+    1 year 1 mon
+    2 mons 1 day
+    3 days 04:05:06.5
+    -1 year -2 mons +3 days -04:05:06
+    1 years 1 mon
+    3 days -1 year -2 mons -04:05:06
+  `.split('\n').slice(0, -1).map(s => s.trim()).forEach(check);
+});

--- a/test.js
+++ b/test.js
@@ -3,7 +3,12 @@
 var pg = require('pg')
 var tape = require('tape')
 var async = require('async')
-var parse = require('.')
+var parse = require('./index')
+
+// Fake promise for older node verions.
+if (typeof Promise === 'undefined') {
+  global.Promise = require('promise-polyfill')
+}
 
 // callback(err, [{
 //  input // String   element of `inputs` array

--- a/test.js
+++ b/test.js
@@ -39,6 +39,10 @@ function selectFromPostgres (callback) {
     callback(err, results)
   }
 
+  // These are actually what Postgres outputs
+  // (I ran original values through `psql`).
+  // We still need to query DB, so we can be 100% sure,
+  // that `.toPostgres()` produces the same value.
   async.map([
     '04:05:06.123456',
     '1 year',
@@ -48,22 +52,22 @@ function selectFromPostgres (callback) {
     '1 year 1 mon',
     '2 mons 1 day',
     '3 days 04:05:06.5',
-    '-1 year -2 mons +3 days -04:05:06',
-    '1 years 1 mon',
-    '3 days -1 year -2 mons -04:05:06',
+    '-1 years -2 mons +3 days -04:05:06',
+    '1 year 1 mon',
+    '-1 years -2 mons +3 days -04:05:06',
     '01:02:03',
     '100:02:03',
     '1 year -32 days',
     '1 day -00:00:03',
     '00:00:00',
     '00:00:00.5',
-    '00:00:00.50',
-    '00:00:00.500',
-    '00:00:00.5000',
-    '00:00:01.100',
     '00:00:00.5',
-    '00:00:00.100500',
-    '00:00:00.100500',
+    '00:00:00.5',
+    '00:00:00.5',
+    '00:00:01.1',
+    '00:00:00.5',
+    '00:00:00.1005',
+    '00:00:00.1005',
     '00:00:00.123456'
   ], iterator, done)
 }


### PR DESCRIPTION
I wrote this for my project so I don't have to wait for fixes, so it uses w/ever I had for linting and tests. It also uses ES2015 syntax and has a few issues in `test.js`. I can fix those and convert code to what you have currently, if you decide to merge.

I'm also not sure what's faster — running 2 small regexes (in my version) or single huge one (currently).

Changes:
- fixes time parsing;
- removes `milliseconds`, changes `seconds` to float;
- defaults units to `0`;
- `.toPostgres()` prints every unit (even in `'0'::interval` case).

TODOs (feel free to add stuff):
- [x] ES5 for `0.x` node versions;
- [x] linting with `standard`;
- [x] fix tests:
  - [x] make CI test older node verions;
  - [x] ~~getting rid of testing against `pg` queries output in tests (maybe?);~~
  - [x] test input values are a mess.
