### PR TITLE
Fix missing escape for dot in time regex fragment

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ var NUMBER = '([+-]?\\d+)'
 var YEAR = NUMBER + '\\s+years?'
 var MONTH = NUMBER + '\\s+mons?'
 var DAY = NUMBER + '\\s+days?'
-var TIME = '([+-])?([\\d]*):(\\d\\d):(\\d\\d).?(\\d{1,6})?'
+var TIME = '([+-])?([\\d]*):(\\d\\d):(\\d\\d)\\.?(\\d{1,6})?'
 var INTERVAL = new RegExp([YEAR, MONTH, DAY, TIME].map(function (regexString) {
   return '(' + regexString + ')?'
 })


### PR DESCRIPTION
See 906c2cab28fe053ba652f4cf1ef79a96f5f8c2ad.