### PR TITLE
Recommend `toISOString` in usage section of readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ var interval = parse('01:02:03')
 //=> {hours: 1, minutes: 2, seconds: 3}
 interval.toPostgres()
 // 3 seconds 2 minutes 1 hours
-interval.toISO()
+interval.toISOString()
 // P0Y0M0DT1H2M3S
 ```
 


### PR DESCRIPTION
Missed this instance in #21.