### PR TITLE
Refactor to improve performance

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,105 @@
+const PostgresInterval = require('./')
+const intervalsToParse = []
+
+const MICROSECONDS = [0, 1, 100, 1000, 10000, 999999]
+const SECONDS = [0, 1, 5, 10, 20, 59]
+const MINUTES = [0, 1, 5, 10, 20, 59]
+const MAX_HOURS = 23
+const MAX_DAYS = 30
+const MAX_MONTHS = 30
+const MAX_YEARS = 30
+
+for (let year = 0; year <= MAX_YEARS; year += 6) {
+  for (let month = 0; month <= MAX_MONTHS; month += 6) {
+    for (let day = 0; day <= MAX_DAYS; day += 6) {
+      for (let hour = 0; hour <= MAX_HOURS; hour += 6) {
+        for (const minute of MINUTES) {
+          for (const second of SECONDS) {
+            for (const microsecond of MICROSECONDS) {
+              let interval = ''
+              if (year > 0) {
+                interval += `${year} year${year === 1 ? '' : 's'} `
+              }
+              if (month > 0) {
+                interval += `${month} mon${month === 1 ? '' : 's'} `
+              }
+              if (day > 0) {
+                interval += `${day} day${day === 1 ? '' : 's'} `
+              }
+              if (
+                hour > 0 ||
+                minute > 0 ||
+                second > 0 ||
+                microsecond > 0 ||
+                (!year && !month && !day)
+              ) {
+                const s = second + microsecond * 1e-6
+                interval += `${String(hour).padStart(2, '0')}:${String(
+                  minute
+                ).padStart(2, '0')}:${(s >= 10 ? '' : '0') + s.toFixed(6)}`
+              }
+              interval = interval.trim()
+              intervalsToParse.push(interval)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+const l = intervalsToParse.length
+console.log(`To process: ${l} intervals`)
+
+async function main() {
+  // First benchmark the full path
+  for (let i = 0; i < 10; i++) {
+    global.gc()
+    await new Promise((resolve) => {
+      process.nextTick(() => {
+        const start = process.hrtime()
+
+        for (let i = 0; i < l; i++) {
+          new PostgresInterval(intervalsToParse[i])
+        }
+        const fin = process.hrtime(start)
+        const dur = fin[0] * 1e3 + fin[1] * 1e-6
+
+        console.log(
+          `Processing ${l} intervals took ${dur.toFixed(1)}ms (${(
+            l / dur
+          ).toFixed(1)} intervals/ms)`
+        )
+        resolve()
+      })
+    })
+  }
+
+  // Now benchmark just the parsing
+  for (let i = 0; i < 10; i++) {
+    global.gc()
+    await new Promise((resolve) => {
+      process.nextTick(() => {
+        const start = process.hrtime()
+
+        for (let i = 0; i < l; i++) {
+          PostgresInterval.parse(intervalsToParse[i])
+        }
+        const fin = process.hrtime(start)
+        const dur = fin[0] * 1e3 + fin[1] * 1e-6
+
+        console.log(
+          `Just parsing ${l} intervals took ${dur.toFixed(1)}ms (${(
+            l / dur
+          ).toFixed(1)} intervals/ms)`
+        )
+        resolve()
+      })
+    })
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/benchmark.js
+++ b/benchmark.js
@@ -51,7 +51,7 @@ for (let year = 0; year <= MAX_YEARS; year += 6) {
 const l = intervalsToParse.length
 console.log(`To process: ${l} intervals`)
 
-async function main() {
+async function main () {
   // First benchmark the full path
   for (let i = 0; i < 10; i++) {
     global.gc()

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const PostgresInterval = require('./')
 const intervalsToParse = []
 
@@ -60,7 +62,7 @@ async function main () {
         const start = process.hrtime()
 
         for (let i = 0; i < l; i++) {
-          new PostgresInterval(intervalsToParse[i])
+          new PostgresInterval(intervalsToParse[i]) // eslint-disable-line no-new
         }
         const fin = process.hrtime(start)
         const dur = fin[0] * 1e3 + fin[1] * 1e-6

--- a/index.js
+++ b/index.js
@@ -11,9 +11,7 @@ function PostgresInterval (raw) {
 }
 const properties = ['seconds', 'minutes', 'hours', 'days', 'months', 'years']
 PostgresInterval.prototype.toPostgres = function () {
-  const filtered = properties.filter(
-    (key) => Object.prototype.hasOwnProperty.call(this, key) && this[key] !== 0
-  )
+  const filtered = properties.filter(key => Object.prototype.hasOwnProperty.call(this, key) && this[key] !== 0)
 
   // In addition to `properties`, we need to account for fractions of seconds.
   if (this.milliseconds && filtered.indexOf('seconds') < 0) {
@@ -28,9 +26,7 @@ PostgresInterval.prototype.toPostgres = function () {
       // Account for fractional part of seconds,
       // remove trailing zeroes.
       if (property === 'seconds' && this.milliseconds) {
-        value = (value + this.milliseconds / 1000)
-          .toFixed(6)
-          .replace(/\.?0+$/, '')
+        value = (value + this.milliseconds / 1000).toFixed(6).replace(/\.?0+$/, '')
       }
 
       return value + ' ' + property
@@ -58,9 +54,13 @@ PostgresInterval.prototype.toISOStringShort = function () {
 }
 
 function toISOString ({ short = false }) {
-  const datePart = dateProperties.map(buildProperty, this).join('')
+  const datePart = dateProperties
+    .map(buildProperty, this)
+    .join('')
 
-  const timePart = timeProperties.map(buildProperty, this).join('')
+  const timePart = timeProperties
+    .map(buildProperty, this)
+    .join('')
 
   if (!timePart.length && !datePart.length) return 'PT0S'
 

--- a/index.js
+++ b/index.js
@@ -137,11 +137,12 @@ function parse (interval) {
   const minutes = minutesString
     ? timeMultiplier * parseInt(minutesString, 10)
     : 0
-  const secondsFloat = parseFloat(secondsString)
+  const secondsFloat = parseFloat(secondsString) || 0
   // secondsFloat is guaranteed to be >= 0, so floor is safe
   const absSeconds = Math.floor(secondsFloat)
   const seconds = timeMultiplier * absSeconds
-  const milliseconds = timeMultiplier * (secondsFloat - absSeconds)
+  // Without the rounding, we end up with decimals like 455.99999999999994 instead of 456
+  const milliseconds = Math.round(timeMultiplier * (secondsFloat - absSeconds) * 1000000) / 1000
   return {
     years,
     months,

--- a/index.js
+++ b/index.js
@@ -115,10 +115,7 @@ function parse (interval) {
     return ZERO_INTERVAL
   }
 
-  const matches = INTERVAL.exec(interval)
-  if (!matches) {
-    throw new Error(`Failed to parse interval '${interval}' from PostgreSQL`)
-  }
+  const matches = INTERVAL.exec(interval) || []
 
   const [
     ,

--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ function PostgresInterval (raw) {
 }
 const properties = ['seconds', 'minutes', 'hours', 'days', 'months', 'years']
 PostgresInterval.prototype.toPostgres = function () {
-  const filtered = properties.filter(key => Object.prototype.hasOwnProperty.call(this, key) && this[key] !== 0)
+  const filtered = properties.filter(
+    (key) => Object.prototype.hasOwnProperty.call(this, key) && this[key] !== 0
+  )
 
   // In addition to `properties`, we need to account for fractions of seconds.
   if (this.milliseconds && filtered.indexOf('seconds') < 0) {
@@ -26,7 +28,9 @@ PostgresInterval.prototype.toPostgres = function () {
       // Account for fractional part of seconds,
       // remove trailing zeroes.
       if (property === 'seconds' && this.milliseconds) {
-        value = (value + this.milliseconds / 1000).toFixed(6).replace(/\.?0+$/, '')
+        value = (value + this.milliseconds / 1000)
+          .toFixed(6)
+          .replace(/\.?0+$/, '')
       }
 
       return value + ' ' + property
@@ -54,13 +58,9 @@ PostgresInterval.prototype.toISOStringShort = function () {
 }
 
 function toISOString ({ short = false }) {
-  const datePart = dateProperties
-    .map(buildProperty, this)
-    .join('')
+  const datePart = dateProperties.map(buildProperty, this).join('')
 
-  const timePart = timeProperties
-    .map(buildProperty, this)
-    .join('')
+  const timePart = timeProperties.map(buildProperty, this).join('')
 
   if (!timePart.length && !datePart.length) return 'PT0S'
 
@@ -110,7 +110,7 @@ const ZERO_INTERVAL = Object.freeze({
   milliseconds: 0.0
 })
 
-function parse(interval) {
+function parse (interval) {
   if (!interval) {
     return ZERO_INTERVAL
   }

--- a/index.js
+++ b/index.js
@@ -140,3 +140,4 @@ function parse (interval) {
       return parsed
     }, {})
 }
+PostgresInterval.parse = parse

--- a/package.json
+++ b/package.json
@@ -30,5 +30,10 @@
     "index.js",
     "index.d.ts",
     "readme.md"
-  ]
+  ],
+  "standard": {
+    "ignore": [
+      "benchmark.js"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,5 @@
     "index.js",
     "index.d.ts",
     "readme.md"
-  ],
-  "standard": {
-    "ignore": [
-      "benchmark.js"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
As raised in #33; this PR improves the performance and readability of the `parse` method in this library.

As requested, I have benchmarked the changes (`benchmark.js` is included in this PR). The results show a 82% increase in performance and reduced memory usage/GC by almost a half.


Note the benchmark should be ran with a command line something like the following:

```
node --nouse_idle_notification --trace_gc --max-old-space-size=4000 --max-semi-space-size=2000 --noconcurrent_sweeping --predictable --expose-gc --trace_gc benchmark.js
```


### Before:

```
[42437:0x47baa30]     3689 ms: Mark-sweep 27.5 (46.3) -> 13.2 (46.3) MB, 8.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) testing GC in old space requested
[42437:0x47baa30]     3713 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3732 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3750 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3769 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3787 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3806 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3825 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
Just parsing 186624 intervals took 152.2ms (1226.5 intervals/ms)
```

(Summary: 1226.5 intervals/ms, 7 scavenge GCs)

### After:

```
[42542:0x4be2a30]     2157 ms: Mark-sweep 24.3 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.914, current mu = 0.913) testing GC in old space requested
[42542:0x4be2a30]     2177 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.913) allocation failure 
[42542:0x4be2a30]     2194 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.913) allocation failure 
[42542:0x4be2a30]     2211 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.913) allocation failure 
[42542:0x4be2a30]     2229 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.913) allocation failure 
Just parsing 186624 intervals took 83.6ms (2231.1 intervals/ms)
```

(Summary: 2231.1 intervals/ms, 4 scavenge GCs)


---

<details>

<summary>Full 'before' benchmark results</summary>

```
[42437:0x47baa30]       28 ms: Scavenge 2.5 (3.0) -> 2.1 (4.0) MB, 0.5 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]       32 ms: Scavenge 2.5 (4.0) -> 2.2 (4.8) MB, 0.6 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]       34 ms: Scavenge 3.1 (6.8) -> 2.3 (6.8) MB, 0.2 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]       38 ms: Scavenge 4.2 (6.8) -> 2.5 (6.8) MB, 0.2 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]       40 ms: Scavenge 4.2 (6.8) -> 2.7 (7.0) MB, 0.2 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]       43 ms: Scavenge 4.4 (7.0) -> 2.8 (7.3) MB, 0.2 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]       56 ms: Scavenge 4.9 (7.5) -> 3.2 (7.7) MB, 0.3 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]       58 ms: Scavenge 5.3 (8.0) -> 3.7 (8.0) MB, 0.3 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]       60 ms: Scavenge 5.5 (12.0) -> 3.9 (12.2) MB, 0.3 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]       66 ms: Scavenge 8.1 (12.6) -> 4.7 (12.9) MB, 0.5 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]      103 ms: Scavenge 8.4 (12.9) -> 5.1 (13.4) MB, 0.6 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]      107 ms: Scavenge 8.8 (13.4) -> 5.5 (13.6) MB, 0.4 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]      110 ms: Scavenge 9.7 (14.2) -> 6.5 (14.7) MB, 0.5 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]      114 ms: Scavenge 10.1 (22.7) -> 6.8 (23.0) MB, 0.6 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]      122 ms: Scavenge 15.3 (23.8) -> 8.5 (24.3) MB, 1.0 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]      130 ms: Scavenge 15.7 (24.3) -> 9.3 (25.1) MB, 1.0 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]      137 ms: Scavenge 16.4 (25.1) -> 10.0 (25.8) MB, 0.9 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]      144 ms: Scavenge 18.5 (27.2) -> 12.0 (27.9) MB, 1.2 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]      151 ms: Mark-sweep 13.8 (43.9) -> 9.2 (42.4) MB, 4.0 / 0.0 ms  (+ 1.4 ms in 28 steps since start of marking, biggest step 0.1 ms, walltime since start of marking 7 ms) (average mu = 1.000, current mu = 1.000) finalize incremental marking via stack guard GC in old space requested
[42437:0x47baa30]      167 ms: Scavenge 25.2 (42.4) -> 11.0 (42.4) MB, 1.4 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42437:0x47baa30]      184 ms: Scavenge 27.1 (44.3) -> 14.4 (45.6) MB, 3.9 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
To process: 186624 intervals
[42437:0x47baa30]      195 ms: Mark-sweep 15.5 (45.8) -> 13.2 (46.0) MB, 7.3 / 0.0 ms  (average mu = 0.836, current mu = 0.836) testing GC in old space requested
[42437:0x47baa30]      226 ms: Scavenge 29.2 (46.0) -> 13.2 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42437:0x47baa30]      247 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42437:0x47baa30]      268 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42437:0x47baa30]      289 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42437:0x47baa30]      310 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42437:0x47baa30]      331 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42437:0x47baa30]      352 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42437:0x47baa30]      373 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42437:0x47baa30]      394 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
Processing 186624 intervals took 200.6ms (930.5 intervals/ms)
[42437:0x47baa30]      404 ms: Mark-sweep 15.1 (46.0) -> 13.2 (46.3) MB, 7.8 / 0.0 ms  (average mu = 0.941, current mu = 0.963) testing GC in old space requested
[42437:0x47baa30]      431 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.941, current mu = 0.963) allocation failure 
[42437:0x47baa30]      452 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.2 / 0.0 ms  (average mu = 0.941, current mu = 0.963) allocation failure 
[42437:0x47baa30]      473 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.941, current mu = 0.963) allocation failure 
[42437:0x47baa30]      495 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.941, current mu = 0.963) allocation failure 
[42437:0x47baa30]      516 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.941, current mu = 0.963) allocation failure 
[42437:0x47baa30]      538 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.941, current mu = 0.963) allocation failure 
[42437:0x47baa30]      559 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.941, current mu = 0.963) allocation failure 
[42437:0x47baa30]      580 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.941, current mu = 0.963) allocation failure 
[42437:0x47baa30]      601 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.941, current mu = 0.963) allocation failure 
Processing 186624 intervals took 199.4ms (936.0 intervals/ms)
[42437:0x47baa30]      612 ms: Mark-sweep 15.0 (46.3) -> 13.2 (46.3) MB, 7.8 / 0.0 ms  (average mu = 0.954, current mu = 0.963) testing GC in old space requested
[42437:0x47baa30]      637 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.954, current mu = 0.963) allocation failure 
[42437:0x47baa30]      658 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.2 / 0.0 ms  (average mu = 0.954, current mu = 0.963) allocation failure 
[42437:0x47baa30]      678 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.954, current mu = 0.963) allocation failure 
[42437:0x47baa30]      700 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.954, current mu = 0.963) allocation failure 
[42437:0x47baa30]      720 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.954, current mu = 0.963) allocation failure 
[42437:0x47baa30]      742 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.954, current mu = 0.963) allocation failure 
[42437:0x47baa30]      763 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.954, current mu = 0.963) allocation failure 
[42437:0x47baa30]      784 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.954, current mu = 0.963) allocation failure 
[42437:0x47baa30]      805 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.954, current mu = 0.963) allocation failure 
Processing 186624 intervals took 190.6ms (979.1 intervals/ms)
[42437:0x47baa30]      815 ms: Mark-sweep 15.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.958, current mu = 0.961) testing GC in old space requested
[42437:0x47baa30]      841 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.958, current mu = 0.961) allocation failure 
[42437:0x47baa30]      862 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.958, current mu = 0.961) allocation failure 
[42437:0x47baa30]      883 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.958, current mu = 0.961) allocation failure 
[42437:0x47baa30]      905 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.958, current mu = 0.961) allocation failure 
[42437:0x47baa30]      926 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.958, current mu = 0.961) allocation failure 
[42437:0x47baa30]      947 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.958, current mu = 0.961) allocation failure 
[42437:0x47baa30]      968 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.958, current mu = 0.961) allocation failure 
[42437:0x47baa30]      989 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.958, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1011 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.958, current mu = 0.961) allocation failure 
Processing 186624 intervals took 197.8ms (943.4 intervals/ms)
[42437:0x47baa30]     1021 ms: Mark-sweep 15.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.960, current mu = 0.961) testing GC in old space requested
[42437:0x47baa30]     1047 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.960, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1067 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.960, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1088 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.960, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1109 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.960, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1130 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.960, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1151 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.960, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1172 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.960, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1193 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.960, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1214 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.960, current mu = 0.961) allocation failure 
Processing 186624 intervals took 190.9ms (977.7 intervals/ms)
[42437:0x47baa30]     1225 ms: Mark-sweep 15.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.961, current mu = 0.961) testing GC in old space requested
[42437:0x47baa30]     1252 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1273 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1295 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1316 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1337 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1359 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1380 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1401 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1422 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
Processing 186624 intervals took 199.6ms (935.1 intervals/ms)
[42437:0x47baa30]     1433 ms: Mark-sweep 15.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.961, current mu = 0.962) testing GC in old space requested
[42437:0x47baa30]     1459 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1479 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1500 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1521 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1542 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1563 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1583 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1604 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1625 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
Processing 186624 intervals took 189.0ms (987.6 intervals/ms)
[42437:0x47baa30]     1635 ms: Mark-sweep 15.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.961, current mu = 0.961) testing GC in old space requested
[42437:0x47baa30]     1663 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1684 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1705 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1726 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1747 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1768 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1789 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1810 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     1832 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
Processing 186624 intervals took 198.5ms (940.0 intervals/ms)
[42437:0x47baa30]     1842 ms: Mark-sweep 15.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.961, current mu = 0.962) testing GC in old space requested
[42437:0x47baa30]     1869 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1889 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1910 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1931 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1951 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1972 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     1993 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     2014 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     2035 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
Processing 186624 intervals took 189.4ms (985.5 intervals/ms)
[42437:0x47baa30]     2045 ms: Mark-sweep 15.0 (46.3) -> 13.2 (46.3) MB, 8.0 / 0.0 ms  (average mu = 0.961, current mu = 0.961) testing GC in old space requested
[42437:0x47baa30]     2073 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     2094 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     2115 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     2136 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     2157 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     2178 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     2200 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     2221 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
[42437:0x47baa30]     2242 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.961) allocation failure 
Processing 186624 intervals took 198.8ms (938.7 intervals/ms)
[42437:0x47baa30]     2252 ms: Mark-sweep 15.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.961, current mu = 0.962) testing GC in old space requested
[42437:0x47baa30]     2278 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     2296 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     2314 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     2333 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     2351 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     2369 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
[42437:0x47baa30]     2388 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.961, current mu = 0.962) allocation failure 
Just parsing 186624 intervals took 152.0ms (1227.8 intervals/ms)
[42437:0x47baa30]     2413 ms: Mark-sweep 27.7 (46.3) -> 13.2 (46.3) MB, 8.0 / 0.0 ms  (average mu = 0.956, current mu = 0.950) testing GC in old space requested
[42437:0x47baa30]     2437 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.956, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2456 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.956, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2474 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.956, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2493 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.956, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2512 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.956, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2530 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.956, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2549 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.956, current mu = 0.950) allocation failure 
Just parsing 186624 intervals took 152.8ms (1221.7 intervals/ms)
[42437:0x47baa30]     2574 ms: Mark-sweep 27.5 (46.3) -> 13.2 (46.3) MB, 8.1 / 0.0 ms  (average mu = 0.953, current mu = 0.950) testing GC in old space requested
[42437:0x47baa30]     2597 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.953, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2616 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.953, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2634 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.953, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2653 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.953, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2671 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.953, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2690 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.953, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2708 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.953, current mu = 0.950) allocation failure 
Just parsing 186624 intervals took 145.9ms (1279.1 intervals/ms)
[42437:0x47baa30]     2733 ms: Mark-sweep 27.5 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.952, current mu = 0.950) testing GC in old space requested
[42437:0x47baa30]     2757 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.952, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2775 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.952, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2794 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.952, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2812 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.952, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2831 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.952, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2849 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.952, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2868 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.952, current mu = 0.950) allocation failure 
Just parsing 186624 intervals took 151.4ms (1233.1 intervals/ms)
[42437:0x47baa30]     2892 ms: Mark-sweep 27.5 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.951, current mu = 0.950) testing GC in old space requested
[42437:0x47baa30]     2916 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.951, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2935 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.951, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2953 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.951, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2971 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.951, current mu = 0.950) allocation failure 
[42437:0x47baa30]     2990 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.951, current mu = 0.950) allocation failure 
[42437:0x47baa30]     3008 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.951, current mu = 0.950) allocation failure 
[42437:0x47baa30]     3027 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.951, current mu = 0.950) allocation failure 
Just parsing 186624 intervals took 145.7ms (1280.5 intervals/ms)
[42437:0x47baa30]     3052 ms: Mark-sweep 27.5 (46.3) -> 13.2 (46.3) MB, 8.0 / 0.0 ms  (average mu = 0.950, current mu = 0.949) testing GC in old space requested
[42437:0x47baa30]     3076 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3094 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3113 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3131 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3150 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3169 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3187 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
Just parsing 186624 intervals took 152.1ms (1226.7 intervals/ms)
[42437:0x47baa30]     3212 ms: Mark-sweep 27.5 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.950, current mu = 0.951) testing GC in old space requested
[42437:0x47baa30]     3236 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.951) allocation failure 
[42437:0x47baa30]     3254 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.951) allocation failure 
[42437:0x47baa30]     3272 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.951) allocation failure 
[42437:0x47baa30]     3290 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.951) allocation failure 
[42437:0x47baa30]     3309 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.951) allocation failure 
[42437:0x47baa30]     3327 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.951) allocation failure 
[42437:0x47baa30]     3346 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.951) allocation failure 
Just parsing 186624 intervals took 145.2ms (1285.4 intervals/ms)
[42437:0x47baa30]     3370 ms: Mark-sweep 27.5 (46.3) -> 13.2 (46.3) MB, 8.0 / 0.0 ms  (average mu = 0.950, current mu = 0.949) testing GC in old space requested
[42437:0x47baa30]     3395 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3413 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3431 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3450 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3469 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3487 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3505 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
Just parsing 186624 intervals took 151.5ms (1231.9 intervals/ms)
[42437:0x47baa30]     3530 ms: Mark-sweep 27.5 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.950, current mu = 0.950) testing GC in old space requested
[42437:0x47baa30]     3554 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.950) allocation failure 
[42437:0x47baa30]     3572 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.950) allocation failure 
[42437:0x47baa30]     3590 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.950) allocation failure 
[42437:0x47baa30]     3609 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.950) allocation failure 
[42437:0x47baa30]     3627 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.950) allocation failure 
[42437:0x47baa30]     3646 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.950) allocation failure 
[42437:0x47baa30]     3664 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.950) allocation failure 
Just parsing 186624 intervals took 145.6ms (1281.7 intervals/ms)
[42437:0x47baa30]     3689 ms: Mark-sweep 27.5 (46.3) -> 13.2 (46.3) MB, 8.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) testing GC in old space requested
[42437:0x47baa30]     3713 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3732 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3750 ms: Scavenge 29.2 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3769 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3787 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3806 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
[42437:0x47baa30]     3825 ms: Scavenge 29.3 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) allocation failure 
Just parsing 186624 intervals took 152.2ms (1226.5 intervals/ms)
[42437:0x47baa30]     3842 ms: Scavenge 27.5 (46.3) -> 13.3 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.950, current mu = 0.949) task 
```
</details>

<details>

<summary>Full 'after' benchmark results</summary>

```
[42542:0x4be2a30]       27 ms: Scavenge 2.5 (3.0) -> 2.1 (4.0) MB, 0.5 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]       31 ms: Scavenge 2.5 (4.0) -> 2.2 (4.8) MB, 0.6 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]       33 ms: Scavenge 3.1 (6.8) -> 2.3 (6.8) MB, 0.2 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]       36 ms: Scavenge 4.2 (6.8) -> 2.5 (6.8) MB, 0.2 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]       39 ms: Scavenge 4.2 (6.8) -> 2.7 (7.0) MB, 0.2 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]       42 ms: Scavenge 4.4 (7.0) -> 2.8 (7.3) MB, 0.3 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]       54 ms: Scavenge 4.9 (7.5) -> 3.2 (7.7) MB, 0.3 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]       56 ms: Scavenge 5.3 (8.0) -> 3.7 (8.0) MB, 0.3 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]       58 ms: Scavenge 5.5 (12.0) -> 3.9 (12.2) MB, 0.3 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]       64 ms: Scavenge 8.1 (12.6) -> 4.7 (12.9) MB, 0.5 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]      102 ms: Scavenge 8.4 (12.9) -> 5.1 (13.4) MB, 0.6 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]      105 ms: Scavenge 8.8 (13.4) -> 5.5 (13.6) MB, 0.4 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]      109 ms: Scavenge 9.7 (14.2) -> 6.5 (14.7) MB, 0.5 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]      113 ms: Scavenge 10.1 (22.7) -> 6.8 (23.0) MB, 0.6 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]      121 ms: Scavenge 15.3 (23.8) -> 8.5 (24.3) MB, 1.0 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]      128 ms: Scavenge 15.7 (24.3) -> 9.3 (25.1) MB, 1.0 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]      135 ms: Scavenge 16.4 (25.1) -> 10.0 (25.8) MB, 1.0 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]      143 ms: Scavenge 18.5 (27.2) -> 12.0 (27.9) MB, 1.3 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]      150 ms: Mark-sweep 13.8 (43.9) -> 9.2 (42.4) MB, 4.2 / 0.0 ms  (+ 1.4 ms in 28 steps since start of marking, biggest step 0.1 ms, walltime since start of marking 7 ms) (average mu = 1.000, current mu = 1.000) finalize incremental marking via stack guard GC in old space requested
[42542:0x4be2a30]      166 ms: Scavenge 25.2 (42.4) -> 11.0 (42.4) MB, 1.5 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
[42542:0x4be2a30]      184 ms: Scavenge 27.1 (44.3) -> 14.4 (45.6) MB, 3.9 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure 
To process: 186624 intervals
[42542:0x4be2a30]      195 ms: Mark-sweep 15.5 (45.8) -> 13.2 (46.0) MB, 7.4 / 0.0 ms  (average mu = 0.836, current mu = 0.836) testing GC in old space requested
[42542:0x4be2a30]      224 ms: Scavenge 29.2 (46.0) -> 13.2 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42542:0x4be2a30]      244 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.2 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42542:0x4be2a30]      260 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42542:0x4be2a30]      276 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42542:0x4be2a30]      292 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
[42542:0x4be2a30]      309 ms: Scavenge 29.2 (46.0) -> 13.3 (46.0) MB, 0.1 / 0.0 ms  (average mu = 0.836, current mu = 0.836) allocation failure 
Processing 186624 intervals took 119.5ms (1561.6 intervals/ms)
[42542:0x4be2a30]      323 ms: Mark-sweep 19.2 (46.0) -> 13.2 (46.3) MB, 7.7 / 0.0 ms  (average mu = 0.913, current mu = 0.939) testing GC in old space requested
[42542:0x4be2a30]      342 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.913, current mu = 0.939) allocation failure 
[42542:0x4be2a30]      358 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.913, current mu = 0.939) allocation failure 
[42542:0x4be2a30]      374 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.913, current mu = 0.939) allocation failure 
[42542:0x4be2a30]      390 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.913, current mu = 0.939) allocation failure 
[42542:0x4be2a30]      406 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.913, current mu = 0.939) allocation failure 
[42542:0x4be2a30]      422 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.913, current mu = 0.939) allocation failure 
Processing 186624 intervals took 104.3ms (1789.9 intervals/ms)
[42542:0x4be2a30]      435 ms: Mark-sweep 18.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.922, current mu = 0.929) testing GC in old space requested
[42542:0x4be2a30]      453 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.922, current mu = 0.929) allocation failure 
[42542:0x4be2a30]      469 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.922, current mu = 0.929) allocation failure 
[42542:0x4be2a30]      485 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.922, current mu = 0.929) allocation failure 
[42542:0x4be2a30]      501 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.922, current mu = 0.929) allocation failure 
[42542:0x4be2a30]      517 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.922, current mu = 0.929) allocation failure 
[42542:0x4be2a30]      533 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.922, current mu = 0.929) allocation failure 
Processing 186624 intervals took 100.8ms (1850.8 intervals/ms)
[42542:0x4be2a30]      548 ms: Mark-sweep 18.0 (46.3) -> 13.2 (46.3) MB, 9.2 / 0.0 ms  (average mu = 0.920, current mu = 0.918) testing GC in old space requested
[42542:0x4be2a30]      567 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.920, current mu = 0.918) allocation failure 
[42542:0x4be2a30]      583 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.920, current mu = 0.918) allocation failure 
[42542:0x4be2a30]      599 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.920, current mu = 0.918) allocation failure 
[42542:0x4be2a30]      615 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.920, current mu = 0.918) allocation failure 
[42542:0x4be2a30]      631 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.920, current mu = 0.918) allocation failure 
[42542:0x4be2a30]      648 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.920, current mu = 0.918) allocation failure 
Processing 186624 intervals took 104.7ms (1782.1 intervals/ms)
[42542:0x4be2a30]      660 ms: Mark-sweep 18.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.925, current mu = 0.930) testing GC in old space requested
[42542:0x4be2a30]      678 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.925, current mu = 0.930) allocation failure 
[42542:0x4be2a30]      694 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.925, current mu = 0.930) allocation failure 
[42542:0x4be2a30]      710 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.925, current mu = 0.930) allocation failure 
[42542:0x4be2a30]      726 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.925, current mu = 0.930) allocation failure 
[42542:0x4be2a30]      743 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.925, current mu = 0.930) allocation failure 
[42542:0x4be2a30]      759 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.925, current mu = 0.930) allocation failure 
Processing 186624 intervals took 100.7ms (1852.7 intervals/ms)
[42542:0x4be2a30]      772 ms: Mark-sweep 18.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.927, current mu = 0.929) testing GC in old space requested
[42542:0x4be2a30]      792 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.927, current mu = 0.929) allocation failure 
[42542:0x4be2a30]      808 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.927, current mu = 0.929) allocation failure 
[42542:0x4be2a30]      824 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.927, current mu = 0.929) allocation failure 
[42542:0x4be2a30]      840 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.927, current mu = 0.929) allocation failure 
[42542:0x4be2a30]      856 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.927, current mu = 0.929) allocation failure 
[42542:0x4be2a30]      873 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.927, current mu = 0.929) allocation failure 
Processing 186624 intervals took 105.7ms (1765.0 intervals/ms)
[42542:0x4be2a30]      885 ms: Mark-sweep 18.0 (46.3) -> 13.2 (46.3) MB, 7.7 / 0.0 ms  (average mu = 0.930, current mu = 0.932) testing GC in old space requested
[42542:0x4be2a30]      904 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.932) allocation failure 
[42542:0x4be2a30]      920 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.932) allocation failure 
[42542:0x4be2a30]      936 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.932) allocation failure 
[42542:0x4be2a30]      952 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.932) allocation failure 
[42542:0x4be2a30]      968 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.932) allocation failure 
[42542:0x4be2a30]      984 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.932) allocation failure 
Processing 186624 intervals took 100.9ms (1849.4 intervals/ms)
[42542:0x4be2a30]      997 ms: Mark-sweep 18.0 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.930, current mu = 0.930) testing GC in old space requested
[42542:0x4be2a30]     1017 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
[42542:0x4be2a30]     1033 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
[42542:0x4be2a30]     1049 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
[42542:0x4be2a30]     1066 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
[42542:0x4be2a30]     1082 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
[42542:0x4be2a30]     1098 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
Processing 186624 intervals took 105.5ms (1768.2 intervals/ms)
[42542:0x4be2a30]     1111 ms: Mark-sweep 18.0 (46.3) -> 13.2 (46.3) MB, 7.8 / 0.0 ms  (average mu = 0.931, current mu = 0.932) testing GC in old space requested
[42542:0x4be2a30]     1130 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.931, current mu = 0.932) allocation failure 
[42542:0x4be2a30]     1146 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.931, current mu = 0.932) allocation failure 
[42542:0x4be2a30]     1162 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.931, current mu = 0.932) allocation failure 
[42542:0x4be2a30]     1178 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.931, current mu = 0.932) allocation failure 
[42542:0x4be2a30]     1194 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.931, current mu = 0.932) allocation failure 
[42542:0x4be2a30]     1210 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.931, current mu = 0.932) allocation failure 
Processing 186624 intervals took 100.7ms (1853.9 intervals/ms)
[42542:0x4be2a30]     1223 ms: Mark-sweep 18.0 (46.3) -> 13.2 (46.3) MB, 7.8 / 0.0 ms  (average mu = 0.930, current mu = 0.930) testing GC in old space requested
[42542:0x4be2a30]     1243 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
[42542:0x4be2a30]     1259 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
[42542:0x4be2a30]     1275 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
[42542:0x4be2a30]     1291 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
[42542:0x4be2a30]     1308 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
[42542:0x4be2a30]     1324 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.930, current mu = 0.930) allocation failure 
Processing 186624 intervals took 105.8ms (1764.4 intervals/ms)
[42542:0x4be2a30]     1337 ms: Mark-sweep 18.0 (46.3) -> 13.2 (46.3) MB, 7.8 / 0.0 ms  (average mu = 0.931, current mu = 0.931) testing GC in old space requested
[42542:0x4be2a30]     1355 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.931, current mu = 0.931) allocation failure 
[42542:0x4be2a30]     1372 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.931, current mu = 0.931) allocation failure 
[42542:0x4be2a30]     1389 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.931, current mu = 0.931) allocation failure 
[42542:0x4be2a30]     1407 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.931, current mu = 0.931) allocation failure 
Just parsing 186624 intervals took 82.0ms (2276.4 intervals/ms)
[42542:0x4be2a30]     1427 ms: Mark-sweep 24.3 (46.3) -> 13.2 (46.3) MB, 8.3 / 0.0 ms  (average mu = 0.921, current mu = 0.908) testing GC in old space requested
[42542:0x4be2a30]     1448 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.921, current mu = 0.908) allocation failure 
[42542:0x4be2a30]     1465 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.921, current mu = 0.908) allocation failure 
[42542:0x4be2a30]     1482 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.921, current mu = 0.908) allocation failure 
[42542:0x4be2a30]     1499 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.921, current mu = 0.908) allocation failure 
Just parsing 186624 intervals took 83.4ms (2238.0 intervals/ms)
[42542:0x4be2a30]     1519 ms: Mark-sweep 24.3 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.917, current mu = 0.914) testing GC in old space requested
[42542:0x4be2a30]     1538 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.917, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1555 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.917, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1573 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.917, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1590 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.917, current mu = 0.914) allocation failure 
Just parsing 186624 intervals took 79.6ms (2344.0 intervals/ms)
[42542:0x4be2a30]     1609 ms: Mark-sweep 24.3 (46.3) -> 13.2 (46.3) MB, 7.8 / 0.0 ms  (average mu = 0.916, current mu = 0.915) testing GC in old space requested
[42542:0x4be2a30]     1630 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.916, current mu = 0.915) allocation failure 
[42542:0x4be2a30]     1647 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.916, current mu = 0.915) allocation failure 
[42542:0x4be2a30]     1664 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.916, current mu = 0.915) allocation failure 
[42542:0x4be2a30]     1681 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.916, current mu = 0.915) allocation failure 
Just parsing 186624 intervals took 83.6ms (2232.0 intervals/ms)
[42542:0x4be2a30]     1701 ms: Mark-sweep 24.3 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.915, current mu = 0.914) testing GC in old space requested
[42542:0x4be2a30]     1721 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.915, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1738 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.915, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1755 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.915, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1772 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.915, current mu = 0.914) allocation failure 
Just parsing 186624 intervals took 79.6ms (2343.3 intervals/ms)
[42542:0x4be2a30]     1792 ms: Mark-sweep 24.3 (46.3) -> 13.2 (46.3) MB, 7.8 / 0.0 ms  (average mu = 0.914, current mu = 0.914) testing GC in old space requested
[42542:0x4be2a30]     1812 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1829 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1847 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1864 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
Just parsing 186624 intervals took 83.7ms (2230.9 intervals/ms)
[42542:0x4be2a30]     1884 ms: Mark-sweep 24.3 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.914, current mu = 0.914) testing GC in old space requested
[42542:0x4be2a30]     1903 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1920 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1937 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     1954 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
Just parsing 186624 intervals took 79.5ms (2347.2 intervals/ms)
[42542:0x4be2a30]     1974 ms: Mark-sweep 24.3 (46.3) -> 13.2 (46.3) MB, 7.8 / 0.0 ms  (average mu = 0.914, current mu = 0.914) testing GC in old space requested
[42542:0x4be2a30]     1995 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     2012 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     2029 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
[42542:0x4be2a30]     2046 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.914) allocation failure 
Just parsing 186624 intervals took 83.4ms (2238.2 intervals/ms)
[42542:0x4be2a30]     2066 ms: Mark-sweep 24.3 (46.3) -> 13.2 (46.3) MB, 7.8 / 0.0 ms  (average mu = 0.914, current mu = 0.915) testing GC in old space requested
[42542:0x4be2a30]     2085 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.915) allocation failure 
[42542:0x4be2a30]     2102 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.915) allocation failure 
[42542:0x4be2a30]     2120 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.915) allocation failure 
[42542:0x4be2a30]     2137 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.915) allocation failure 
Just parsing 186624 intervals took 79.9ms (2336.5 intervals/ms)
[42542:0x4be2a30]     2157 ms: Mark-sweep 24.3 (46.3) -> 13.2 (46.3) MB, 7.9 / 0.0 ms  (average mu = 0.914, current mu = 0.913) testing GC in old space requested
[42542:0x4be2a30]     2177 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.913) allocation failure 
[42542:0x4be2a30]     2194 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.913) allocation failure 
[42542:0x4be2a30]     2211 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.913) allocation failure 
[42542:0x4be2a30]     2229 ms: Scavenge 29.2 (46.3) -> 13.2 (46.3) MB, 0.1 / 0.0 ms  (average mu = 0.914, current mu = 0.913) allocation failure 
Just parsing 186624 intervals took 83.6ms (2231.1 intervals/ms)
```

</details>

Closes #33
