### PR TITLE
Fix parsing months

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function toISOString ({ short = false }) {
 
 const NUMBER = '([+-]?\\d+)'
 const YEAR = `${NUMBER}\\s+years?`
-const MONTH = `${NUMBER}\\s+months?`
+const MONTH = `${NUMBER}\\s+mon(th)?s?`
 const DAY = `${NUMBER}\\s+days?`
 // NOTE: PostgreSQL automatically overflows seconds into minutes and minutes
 // into hours, so we can rely on minutes and seconds always being 2 digits
@@ -124,6 +124,7 @@ function parse (interval) {
     ,
     yearsString,
     monthsString,
+    ,
     daysString,
     plusMinusTime,
     hoursString,

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function toISOString ({ short = false }) {
 
 const NUMBER = '([+-]?\\d+)'
 const YEAR = `${NUMBER}\\s+years?`
-const MONTH = `${NUMBER}\\s+mons?`
+const MONTH = `${NUMBER}\\s+months?`
 const DAY = `${NUMBER}\\s+days?`
 // NOTE: PostgreSQL automatically overflows seconds into minutes and minutes
 // into hours, so we can rely on minutes and seconds always being 2 digits

--- a/test.js
+++ b/test.js
@@ -30,6 +30,9 @@ test(function (t) {
     t.deepEqual(interval('3 years'), Object.assign(new PostgresInterval(), {
       years: 3
     }))
+    t.deepEqual(interval('2 mons'), Object.assign(new PostgresInterval(), {
+      months: 2
+    }))
     t.deepEqual(interval('2 months'), Object.assign(new PostgresInterval(), {
       months: 2
     }))
@@ -117,6 +120,7 @@ test(function (t) {
     t.equal(interval('00:00:00.100500').toISOStringShort(), 'PT0.1005S')
     t.equal(interval('00:00:00.123456').toISOStringShort(), 'PT0.123456S')
     t.equal(interval('-00:00:00.123456').toISOStringShort(), 'PT-0.123456S')
+    t.equal(interval('3 years 1 mon 10 days').toISOStringShort(), 'P3Y1M10D')
     t.equal(interval('3 years 1 month 10 days').toISOStringShort(), 'P3Y1M10D')
     t.end()
   })

--- a/test.js
+++ b/test.js
@@ -27,6 +27,21 @@ test(function (t) {
     t.equal(interval('00:00:00.5000').milliseconds, 500)
     t.equal(interval('00:00:00.100500').milliseconds, 100.5)
 
+    t.deepEqual(interval('3 years'), Object.assign(new PostgresInterval(), {
+      years: 3
+    }))
+    t.deepEqual(interval('2 months'), Object.assign(new PostgresInterval(), {
+      months: 2
+    }))
+    t.deepEqual(interval('10 days'), Object.assign(new PostgresInterval(), {
+      days: 10
+    }))
+    t.deepEqual(interval('3 years 2 months 10 days'), Object.assign(new PostgresInterval(), {
+      years: 3,
+      months: 2,
+      days: 10
+    }))
+
     t.test('zero', function (t) {
       const result = interval('00:00:00')
       t.equal(result.years, 0)
@@ -102,6 +117,7 @@ test(function (t) {
     t.equal(interval('00:00:00.100500').toISOStringShort(), 'PT0.1005S')
     t.equal(interval('00:00:00.123456').toISOStringShort(), 'PT0.123456S')
     t.equal(interval('-00:00:00.123456').toISOStringShort(), 'PT-0.123456S')
+    t.equal(interval('3 years 1 month 10 days').toISOStringShort(), 'P3Y1M10D')
     t.end()
   })
 


### PR DESCRIPTION
Follow-up of #42 

I would expect that parsing does the same thing as postgres's parsing. In postgres, if you  `SELECT '3 months'::interval;` it does get you a 3 month interval. This PR does this while maintaining backward compatibility for `mon`.