### PR TITLE
extended parser to support verbose hour to ms format

### DIFF
--- a/test.js
+++ b/test.js
@@ -65,6 +65,9 @@ test(function (t) {
     t.equal(interval('00:00:00.100500').toPostgres(), '0.1005 seconds')
     t.equal(interval('00:00:00.123456').toPostgres(), '0.123456 seconds')
     t.equal(interval('-00:00:00.123456').toPostgres(), '-0.123456 seconds')
+    t.equal(interval('02:10:00').toPostgres(), '2 hours 10 minutes')
+    t.equal(interval('2 hours 10 minutes').toPostgres(), '2 hours 10 minutes')
+    t.equal(interval('-10 years 5 hours -10 minutes').toPostgres(), '-10 years 5 hours -10 minutes')
 
     t.end()
   })


### PR DESCRIPTION
Hi! 

I encountered a small problem while using this package:

When converting an interval that only consists of seconds, minutes or hours (so no years/months/days) to a postgres interval string it cannot be parsed again.

For example:

```
const working = interval('02:10:00).toPostgres() // "2 hours 10 minutes"
const not_working = interval(working.toPostgres()) // expected: "2 hours 10 minutes" actual: "0"
```

I fixed this by enabling to parse these verbose format of these kinds of intervals.