### PR TITLE
refactor: improve performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,36 +17,61 @@ function PostgresInterval (raw) {
 
   parse(this, raw)
 }
-const properties = ['years', 'months', 'days', 'hours', 'minutes', 'seconds']
-PostgresInterval.prototype.toPostgres = function () {
-  const filtered = properties.filter(
-    (key) => Object.prototype.hasOwnProperty.call(this, key) && this[key] !== 0
-  )
 
-  // In addition to `properties`, we need to account for fractions of seconds.
-  if (this.milliseconds && !filtered.includes('seconds')) {
-    filtered.push('seconds')
+PostgresInterval.prototype.toPostgres = function () {
+  let postgresString = ''
+
+  if (this.years) {
+    postgresString += this.years === 1 ? this.years + ' year' : this.years + ' years'
   }
 
-  if (filtered.length === 0) return '0'
-  return filtered
-    .map(function (property) {
-      let value = this[property] || 0
+  if (this.months) {
+    if (postgresString.length) {
+      postgresString += ' '
+    }
 
-      // Account for fractional part of seconds,
-      // remove trailing zeroes.
-      if (property === 'seconds' && this.milliseconds) {
-        value = (value + this.milliseconds / 1000)
-          .toFixed(6)
-          .replace(/\.?0+$/, '')
-      }
+    postgresString += this.months === 1 ? this.months + ' month' : this.months + ' months'
+  }
 
-      // fractional seconds will be a String, all others are Number
-      const isSingular = String(value) === '1'
-      // Remove plural 's' when the value is singular
-      return value + ' ' + (isSingular ? property.replace(/s$/, '') : property)
-    }, this)
-    .join(' ')
+  if (this.days) {
+    if (postgresString.length) {
+      postgresString += ' '
+    }
+
+    postgresString += this.days === 1 ? this.days + ' day' : this.days + ' days'
+  }
+
+  if (this.hours) {
+    if (postgresString.length) {
+      postgresString += ' '
+    }
+
+    postgresString += this.hours === 1 ? this.hours + ' hour' : this.hours + ' hours'
+  }
+
+  if (this.minutes) {
+    if (postgresString.length) {
+      postgresString += ' '
+    }
+
+    postgresString += this.minutes === 1 ? this.minutes + ' minute' : this.minutes + ' minutes'
+  }
+
+  if (this.seconds || this.milliseconds) {
+    if (postgresString.length) {
+      postgresString += ' '
+    }
+
+    if (this.milliseconds) {
+      const value = Math.trunc((this.seconds + this.milliseconds / 1000) * 1000000) / 1000000
+
+      postgresString += value === 1 ? value + ' second' : value + ' seconds'
+    } else {
+      postgresString += this.seconds === 1 ? this.seconds + ' second' : this.seconds + ' seconds'
+    }
+  }
+
+  return postgresString === '' ? '0' : postgresString
 }
 
 const propertiesISOEquivalent = {

--- a/test.js
+++ b/test.js
@@ -66,6 +66,7 @@ test(function (t) {
     t.equal(interval('00:00:00.100500').toPostgres(), '0.1005 seconds')
     t.equal(interval('00:00:00.123456').toPostgres(), '0.123456 seconds')
     t.equal(interval('-00:00:00.123456').toPostgres(), '-0.123456 seconds')
+    t.equal(interval('-00:00:59.999999').toPostgres(), '-59.999999 seconds')
 
     t.end()
   })

--- a/test.js
+++ b/test.js
@@ -82,6 +82,7 @@ test(function (t) {
     t.equal(interval('00:00:00.100500').toISOString(), 'P0Y0M0DT0H0M0.1005S')
     t.equal(interval('00:00:00.123456').toISOString(), 'P0Y0M0DT0H0M0.123456S')
     t.equal(interval('-00:00:00.123456').toISOString(), 'P0Y0M0DT0H0M-0.123456S')
+    t.equal(interval('-00:00:59.999999').toISOString(), 'P0Y0M0DT0H0M-59.999999S')
     t.end()
   })
 

--- a/test.js
+++ b/test.js
@@ -26,6 +26,7 @@ test(function (t) {
     t.equal(interval('00:00:00.500').milliseconds, 500)
     t.equal(interval('00:00:00.5000').milliseconds, 500)
     t.equal(interval('00:00:00.100500').milliseconds, 100.5)
+    t.equal(interval('00:00:00.1005005').milliseconds, 100.5005)
 
     t.test('zero', function (t) {
       const result = interval('00:00:00')


### PR DESCRIPTION
Hello o/

I rewrote the `parse`, `toISOString` and `toPostgres` logic, here is the result:

## `parse`

For `parse`, an improvement from 3x to 5x

```
parse('01:02:03.456') x 1,484,034 ops/sec ±1.18% (89 runs sampled)
parse('-01:02:03.456') x 1,383,647 ops/sec ±1.46% (89 runs sampled)
parse('00:00:00.5') x 1,544,277 ops/sec ±1.64% (81 runs sampled)
parse('1 year -32 days') x 1,638,661 ops/sec ±1.15% (89 runs sampled)
parse('1 day -00:00:03') x 1,532,647 ops/sec ±1.27% (88 runs sampled)

fastParse('01:02:03.456') x 7,784,376 ops/sec ±1.60% (88 runs sampled)
fastParse('-01:02:03.456') x 6,785,128 ops/sec ±1.34% (86 runs sampled)
fastParse('00:00:00.5') x 8,059,423 ops/sec ±1.39% (89 runs sampled)
fastParse('1 year -32 days') x 8,165,400 ops/sec ±2.20% (84 runs sampled)
fastParse('1 day -00:00:03') x 5,109,219 ops/sec ±2.93% (78 runs sampled)
Fastest is fastParse('1 year -32 days')
```

<details>

<summary>benchmark.js</summary>

```js
var Benchmark = require('benchmark');
var parse = require('postgres-interval');
var fastParse = require('./faster-postres-interval');

var suite = new Benchmark.Suite();

const testCases = ['01:02:03.456', '-01:02:03.456', '00:00:00.5', '1 year -32 days', '1 day -00:00:03'];

for (const testCase of testCases) {
  suite.add(`parse('${testCase}')`, function () {
    const r = parse(testCase);
  });
}

for (const testCase of testCases) {
  suite.add(`fastParse('${testCase}')`, function () {
    const r = fastParse(testCase);
  });
}

suite
  // add listeners
  .on('cycle', function (event) {
    console.log(String(event.target));
  })
  .on('complete', function () {
    console.log('Fastest is ' + this.filter('fastest').map('name'));
  })
  .run({
    async: true,
  });
```

</details>

## `toISOString`

For `toISOString`, an improvement from 4x to 10x.

```
parse('01:02:03.456').toISOString() x 875,911 ops/sec ±1.71% (86 runs sampled)
parse('-01:02:03.456').toISOString() x 860,124 ops/sec ±1.30% (87 runs sampled)
parse('00:00:00.5').toISOString() x 935,790 ops/sec ±1.44% (87 runs sampled)
parse('1 year -32 days').toISOString() x 1,431,290 ops/sec ±1.73% (87 runs sampled)
parse('1 day -00:00:03').toISOString() x 1,441,589 ops/sec ±1.56% (89 runs sampled)

fastParse('01:02:03.456').toISOString() x 8,527,830 ops/sec ±1.61% (86 runs sampled)
fastParse('-01:02:03.456').toISOString() x 8,919,273 ops/sec ±1.85% (86 runs sampled)
fastParse('00:00:00.5').toISOString() x 3,741,533 ops/sec ±1.44% (87 runs sampled)
fastParse('1 year -32 days').toISOString() x 9,257,344 ops/sec ±1.53% (87 runs sampled)
fastParse('1 day -00:00:03').toISOString() x 9,607,134 ops/sec ±1.41% (91 runs sampled)
Fastest is fastParse('1 day -00:00:03').toISOString()
```

<details>

<summary>benchmark.js</summary>

```js
var Benchmark = require('benchmark');
var parse = require('postgres-interval');
var fastParse = require('./faster-postres-interval');

var suite = new Benchmark.Suite();

const testCases = ['01:02:03.456', '-01:02:03.456', '00:00:00.5', '1 year -32 days', '1 day -00:00:03'];

for (const testCase of testCases) {
  const oldInterval = parse(testCase);

  suite.add(`parse('${testCase}').toISOString()`, function () {
    const r = oldInterval.toISOString();
  });
}

for (const testCase of testCases) {
  const newInterval = fastParse(testCase);

  suite.add(`fastParse('${testCase}').toISOString()`, function () {
    const r = newInterval.toISOString();
  });
}

suite
  // add listeners
  .on('cycle', function (event) {
    console.log(String(event.target));
  })
  .on('complete', function () {
    console.log('Fastest is ' + this.filter('fastest').map('name'));
  })
  .run({
    async: true,
  });
```

</details>

## `toPostgres`

For `toPostgres`, an improvement from 11x to 21x.

```
parse('01:02:03.456').toPostgres() x 788,635 ops/sec ±1.52% (86 runs sampled)
parse('-01:02:03.456').toPostgres() x 879,604 ops/sec ±2.00% (89 runs sampled)
parse('00:00:00.5').toPostgres() x 1,242,873 ops/sec ±1.39% (87 runs sampled)
parse('1 year -32 days').toPostgres() x 1,533,069 ops/sec ±1.19% (87 runs sampled)
parse('1 day -00:00:03').toPostgres() x 1,548,943 ops/sec ±1.49% (88 runs sampled)

fastParse('01:02:03.456').toPostgres() x 10,782,644 ops/sec ±1.52% (89 runs sampled)
fastParse('-01:02:03.456').toPostgres() x 12,073,862 ops/sec ±1.47% (91 runs sampled)
fastParse('00:00:00.5').toPostgres() x 26,570,665 ops/sec ±1.50% (83 runs sampled)
fastParse('1 year -32 days').toPostgres() x 19,176,409 ops/sec ±1.34% (88 runs sampled)
fastParse('1 day -00:00:03').toPostgres() x 17,839,091 ops/sec ±1.56% (86 runs sampled)
Fastest is fastParse('00:00:00.5').toPostgres()
```

<details>

<summary>benchmark.js</summary>

```js
var Benchmark = require('benchmark');
var parse = require('postgres-interval');
var fastParse = require('./faster-postres-interval');

var suite = new Benchmark.Suite();

const testCases = ['01:02:03.456', '-01:02:03.456', '00:00:00.5', '1 year -32 days', '1 day -00:00:03'];

for (const testCase of testCases) {
  const oldInterval = parse(testCase);

  suite.add(`parse('${testCase}').toPostgres()`, function () {
    const r = oldInterval.toPostgres();
  });
}

for (const testCase of testCases) {
  const newInterval = fastParse(testCase);

  suite.add(`fastParse('${testCase}').toPostgres()`, function () {
    const r = newInterval.toPostgres();
  });
}

suite
  // add listeners
  .on('cycle', function (event) {
    console.log(String(event.target));
  })
  .on('complete', function () {
    console.log('Fastest is ' + this.filter('fastest').map('name'));
  })
  .run({
    async: true,
  });
```

</details>
