### PR TITLE
fix: parse leading zeroes in milliseconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,34 +157,27 @@ function readNextNum (interval) {
 }
 
 function parseMillisecond (interval) {
+  const previousPosition = position.value
   const currentValue = readNextNum(interval)
+  const valueStringLength = position.value - previousPosition
 
-  if (currentValue < 10) {
-    return currentValue * 100
-  }
-
-  if (currentValue < 100) {
-    return currentValue * 10
-  }
-
-  if (currentValue < 1000) {
-    return currentValue
-  }
-
-  if (currentValue < 10000) {
-    return currentValue / 10
-  }
-
-  if (currentValue < 100000) {
-    return currentValue / 100
-  }
-
-  if (currentValue < 1000000) {
-    return currentValue / 1000
+  switch (valueStringLength) {
+    case 1:
+      return currentValue * 100
+    case 2:
+      return currentValue * 10
+    case 3:
+      return currentValue
+    case 4:
+      return currentValue / 10
+    case 5:
+      return currentValue / 100
+    case 6:
+      return currentValue / 1000
   }
 
   // slow path
-  const remainder = currentValue.toString().length - 3
+  const remainder = valueStringLength - 3
   return currentValue / Math.pow(10, remainder)
 }
 

--- a/test.js
+++ b/test.js
@@ -27,6 +27,12 @@ test(function (t) {
     t.equal(interval('00:00:00.5000').milliseconds, 500)
     t.equal(interval('00:00:00.100500').milliseconds, 100.5)
     t.equal(interval('00:00:00.1005005').milliseconds, 100.5005)
+    t.equal(interval('00:00:00.05').milliseconds, 50)
+    t.equal(interval('00:00:00.005').milliseconds, 5)
+    t.equal(interval('00:00:00.0005').milliseconds, 0.5)
+    t.equal(interval('00:00:00.00005').milliseconds, 0.05)
+    t.equal(interval('00:00:00.000005').milliseconds, 0.005)
+    t.equal(interval('00:00:00.0000005').milliseconds, 0.0005)
 
     t.test('zero', function (t) {
       const result = interval('00:00:00')


### PR DESCRIPTION
Fix for issue #49 by comparing string length instead of the parsed number itself

Not only does this fix the issue, but (at least on my venerable laptop) it also makes the parsing benchmarks go slightly faster :)

benchmarks before:

```
To process: 186624 intervals
Processing 186624 intervals took 86.6ms (2155.3 intervals/ms)
Processing 186624 intervals took 92.5ms (2017.0 intervals/ms)
Processing 186624 intervals took 78.9ms (2365.1 intervals/ms)
Processing 186624 intervals took 94.0ms (1985.4 intervals/ms)
Processing 186624 intervals took 91.3ms (2044.8 intervals/ms)
Processing 186624 intervals took 87.9ms (2124.1 intervals/ms)
Processing 186624 intervals took 91.5ms (2038.6 intervals/ms)
Processing 186624 intervals took 89.4ms (2087.2 intervals/ms)
Processing 186624 intervals took 91.5ms (2039.1 intervals/ms)
Processing 186624 intervals took 94.6ms (1973.1 intervals/ms)
Just parsing 186624 intervals took 84.3ms (2213.4 intervals/ms)
Just parsing 186624 intervals took 52.8ms (3536.8 intervals/ms)
Just parsing 186624 intervals took 52.3ms (3569.4 intervals/ms)
Just parsing 186624 intervals took 55.3ms (3374.2 intervals/ms)
Just parsing 186624 intervals took 52.7ms (3539.9 intervals/ms)
Just parsing 186624 intervals took 54.0ms (3458.5 intervals/ms)
Just parsing 186624 intervals took 52.1ms (3580.6 intervals/ms)
Just parsing 186624 intervals took 53.7ms (3475.5 intervals/ms)
Just parsing 186624 intervals took 51.5ms (3621.2 intervals/ms)
Just parsing 186624 intervals took 53.1ms (3513.3 intervals/ms)
```

benchmarks after:
```
To process: 186624 intervals
Processing 186624 intervals took 89.5ms (2085.9 intervals/ms)
Processing 186624 intervals took 90.7ms (2057.8 intervals/ms)
Processing 186624 intervals took 92.4ms (2020.2 intervals/ms)
Processing 186624 intervals took 92.5ms (2017.5 intervals/ms)
Processing 186624 intervals took 89.2ms (2093.3 intervals/ms)
Processing 186624 intervals took 91.0ms (2051.1 intervals/ms)
Processing 186624 intervals took 89.2ms (2093.3 intervals/ms)
Processing 186624 intervals took 88.1ms (2118.6 intervals/ms)
Processing 186624 intervals took 90.7ms (2057.0 intervals/ms)
Processing 186624 intervals took 80.4ms (2320.6 intervals/ms)
Just parsing 186624 intervals took 80.9ms (2308.1 intervals/ms)
Just parsing 186624 intervals took 51.2ms (3646.6 intervals/ms)
Just parsing 186624 intervals took 50.3ms (3709.7 intervals/ms)
Just parsing 186624 intervals took 52.4ms (3560.8 intervals/ms)
Just parsing 186624 intervals took 50.6ms (3689.6 intervals/ms)
Just parsing 186624 intervals took 51.2ms (3643.6 intervals/ms)
Just parsing 186624 intervals took 49.8ms (3747.2 intervals/ms)
Just parsing 186624 intervals took 51.4ms (3630.7 intervals/ms)
Just parsing 186624 intervals took 51.1ms (3650.7 intervals/ms)
Just parsing 186624 intervals took 50.6ms (3689.6 intervals/ms)
```