### PR TITLE
Add support for full postgres string parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ function parse (instance, interval) {
   let nextNegative = 1
 
   while (position.value < interval.length) {
-    const char = interval[position.value]
+    let char = interval[position.value]
 
     if (char === '-') {
       nextNegative = -1
@@ -234,14 +234,28 @@ function parse (instance, interval) {
       // skip space
       position.value++
 
-      const unit = interval[position.value]
+      char = interval[position.value]
 
-      if (unit === 'y') {
+      if (char === 'y') {
         instance.years = currentValue ? nextNegative * currentValue : 0
-      } else if (unit === 'm') {
-        instance.months = currentValue ? nextNegative * currentValue : 0
-      } else if (unit === 'd') {
+      } else if (char === 'm') {
+        // go to the first char that can be used to identify months, minutes or milliseconds
+        position.value += 3
+        char = interval[position.value]
+
+        if (char === 't') {
+          instance.months = currentValue ? nextNegative * currentValue : 0
+        } else if (char === 'u') {
+          instance.minutes = currentValue ? nextNegative * currentValue : 0
+        } else if (char === 'l') {
+          instance.milliseconds = currentValue ? nextNegative * currentValue : 0
+        }
+      } else if (char === 'd') {
         instance.days = currentValue ? nextNegative * currentValue : 0
+      } else if (char === 'h') {
+        instance.hours = currentValue ? nextNegative * currentValue : 0
+      } else if (char === 's') {
+        instance.seconds = currentValue ? nextNegative * currentValue : 0
       }
 
       nextNegative = 1

--- a/test.js
+++ b/test.js
@@ -19,6 +19,17 @@ test(function (t) {
       seconds: -3,
       milliseconds: -456
     }))
+    t.deepEqual(interval('1 year 2 months 3 days 4 hours 5 minutes 6 seconds 7 milliseconds'),
+      Object.assign(new PostgresInterval(), {
+        years: 1,
+        months: 2,
+        days: 3,
+        hours: 4,
+        minutes: 5,
+        seconds: 6,
+        milliseconds: 7
+      })
+    )
 
     t.equal(interval('00:00:00-5').milliseconds, 0, 'invalid interval format')
     t.equal(interval('00:00:00.5').milliseconds, 500)


### PR DESCRIPTION
Hi, this is a small PR that fixes a problem related to postgres string parsing our team stumbled upon.

### How to reproduce?

```
interval('1 year 2 months 3 days 4 hours 5 minutes 6 seconds 7 milliseconds')
```

### Actual behavior

```
PostgresInterval {
  years: 1,
  months: 7,
  days: 3,
  hours: 0,
  minutes: 0,
  seconds: 0,
  milliseconds: 0
}
```

### Expected behavior

```
PostgresInterval {
  years: 1,
  months: 2,
  days: 3,
  hours: 4,
  minutes: 5,
  seconds: 6,
  milliseconds: 7
}
```